### PR TITLE
Show units on recipe page

### DIFF
--- a/src/components/RecipeDetail/RecipeIngredients.tsx
+++ b/src/components/RecipeDetail/RecipeIngredients.tsx
@@ -29,7 +29,8 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 
-import type { Ingredient } from "@/components/ShoppingBag/types";
+import { Ingredient } from "@prisma/client";
+import { formatUnit } from "@/utils/ingredientUnits";
 
 const FormSchema = z.object({
   ingredientIds: z.array(z.number()),
@@ -121,10 +122,12 @@ export const RecipeIngredients = ({ ingredients }: Props) => {
                           }
                         />
                       </FormControl>
-                      <FormLabel className="cursor-pointer text-base">
-                        <span className="font-semibold">{ingredient.name}</span>{" "}
-                        - {ingredient.quantity}{" "}
-                        {ingredient.notes && `(${ingredient.notes})`}
+                      <FormLabel className="cursor-pointer space-x-3 text-base">
+                        <span className="font-semibold">{ingredient.name}</span>
+                        <span className="text-muted-foreground">
+                          {ingredient.quantity}
+                          {formatUnit(ingredient.unit, "short")}
+                        </span>
                       </FormLabel>
                     </FormItem>
                   )}

--- a/src/components/ShoppingBag/ListItemHead.tsx
+++ b/src/components/ShoppingBag/ListItemHead.tsx
@@ -1,8 +1,11 @@
 import { Checkbox } from "@/components/ui/checkbox";
+import { Ingredient } from "@prisma/client";
 
-import { Ingredient } from "./types";
+type Props = {
+  name: Ingredient["name"];
+};
 
-export const ListItemHead = ({ name }: Ingredient) => {
+export const ListItemHead = ({ name }: Props) => {
   return (
     <label className="flex grow cursor-pointer items-center gap-2">
       <Checkbox className="peer size-5" />

--- a/src/components/ShoppingBag/ListItemQuantityControls.tsx
+++ b/src/components/ShoppingBag/ListItemQuantityControls.tsx
@@ -2,15 +2,18 @@ import { Plus, Minus, Trash2 } from "lucide-react";
 
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-
-import type { Ingredient } from "./types";
+import { Ingredient } from "@prisma/client";
 
 /*
 Read about the accessibility approach here
 https://lucide.dev/guide/advanced/accessibility#on-icon-buttons
 */
 
-export const ListItemQuantityControls = ({ quantity }: Ingredient) => {
+type Props = {
+  quantity: Ingredient["quantity"];
+};
+
+export const ListItemQuantityControls = ({ quantity }: Props) => {
   const buttonClass = "[&_svg]:size-5";
   return (
     <div className="flex gap-2">

--- a/src/components/ShoppingBag/ShoppingList.tsx
+++ b/src/components/ShoppingBag/ShoppingList.tsx
@@ -2,9 +2,9 @@
 
 import { ShoppingBagIcon } from "lucide-react";
 
+import type { Ingredient } from "@prisma/client";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ShoppingListItem } from "@/components/ShoppingBag/ShoppingListItem";
-import type { Ingredient } from "./types";
 
 // TODO: Fetch actual data from db and bring back ssr and translations
 export const ShoppingBag = () => {
@@ -29,7 +29,7 @@ export const ShoppingBag = () => {
         <ScrollArea className="px-2 py-1">
           <div className="flex flex-col gap-2">
             {shoppingBagItems.map((item, index) => (
-              <ShoppingListItem key={index} {...item} />
+              <ShoppingListItem key={index} ingredient={item} />
             ))}
           </div>
         </ScrollArea>

--- a/src/components/ShoppingBag/ShoppingListItem.tsx
+++ b/src/components/ShoppingBag/ShoppingListItem.tsx
@@ -1,13 +1,17 @@
+import type { Ingredient } from "@prisma/client";
+
 import { ListItemHead } from "./ListItemHead";
 import { ListItemQuantityControls } from "./ListItemQuantityControls";
 
-import type { Ingredient } from "./types";
+type Props = {
+  ingredient: Ingredient;
+};
 
-export const ShoppingListItem = (props: Ingredient) => {
+export const ShoppingListItem = ({ ingredient }: Props) => {
   return (
     <div className="flex items-center justify-between gap-4 rounded-lg border px-2 py-1">
-      <ListItemHead {...props} />
-      <ListItemQuantityControls {...props} />
+      <ListItemHead name={ingredient.name} />
+      <ListItemQuantityControls quantity={ingredient.quantity} />
     </div>
   );
 };

--- a/src/components/ShoppingBag/types.ts
+++ b/src/components/ShoppingBag/types.ts
@@ -1,6 +1,0 @@
-export type Ingredient = {
-  id: number;
-  name: string;
-  quantity: number | string;
-  notes?: string;
-};


### PR DESCRIPTION
Show ingredient units on recipe page. Also removes old `Ingredient` type and uses the one from prisma client
Closes #77 

![image](https://github.com/user-attachments/assets/efb1dd90-d6b5-42da-859a-b00721e58fbb)
